### PR TITLE
fix for build warning 

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Asynchronous HTTP and WebSocket Server Library for ESP32
 paragraph=Supports: WebSocket, SSE, Authentication, Arduino Json 7, File Upload, Static File serving, URL Rewrite, URL Redirect, etc
 category=Other
 url=https://github.com/mathieucarbou/ESPAsyncWebServer
-architectures=8
+architectures=esp32
 license=LGPL-3.0


### PR DESCRIPTION
fix for warning WARNING: library ESP Async WebServer claims to run on 8 architecture(s) and may be incompatible with your current board which runs on esp32 architecture(s).