### PR TITLE
Some websocket code cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This fork is based on [yubox-node-org/ESPAsyncWebServer](https://github.com/yubo
 - [#13](https://github.com/mathieucarbou/ESPAsyncWebServer/pull/13) ([@tueddy](https://github.com/tueddy)): Compile with Arduino 3 (ESP-IDF 5.1)
 - [#14](https://github.com/mathieucarbou/ESPAsyncWebServer/pull/14) ([@nilo85](https://github.com/nilo85)): Add support for Auth & GET requests in AsyncCallbackJsonWebHandler
 - Added `setAuthentication(const String& username, const String& password)`
-- Added `StreamConcat` example to shoiw how to stream multiple files in one response
+- Added `StreamConcat` example to show how to stream multiple files in one response
 - Remove filename after inline in Content-Disposition header according to RFC2183
 - Depends on `mathieucarbou/Async TCP @ ^3.1.4`
 - Arduino 3 / ESP-IDF 5.1 compatibility

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ This fork is based on [yubox-node-org/ESPAsyncWebServer](https://github.com/yubo
 - [#13](https://github.com/mathieucarbou/ESPAsyncWebServer/pull/13) ([@tueddy](https://github.com/tueddy)): Compile with Arduino 3 (ESP-IDF 5.1)
 - [#14](https://github.com/mathieucarbou/ESPAsyncWebServer/pull/14) ([@nilo85](https://github.com/nilo85)): Add support for Auth & GET requests in AsyncCallbackJsonWebHandler
 - Added `setAuthentication(const String& username, const String& password)`
-- Added `StreamConcat` example to shoiw how to stream multiple files in one response
+- Added `StreamConcat` example to show how to stream multiple files in one response
 - Remove filename after inline in Content-Disposition header according to RFC2183
 - Depends on `mathieucarbou/Async TCP @ ^3.1.4`
 - Arduino 3 / ESP-IDF 5.1 compatibility


### PR DESCRIPTION
a bit of tidy work
add explicit constructors
remove extra calls, etc...

run checked, gives a tiny bit of reduction in code size for my project
```
// this PR 
Flash: [========  ]  82.5% (used 1460245 bytes from 1769472 bytes)     
// orig
Flash: [========  ]  82.5% (used 1460669 bytes from 1769472 bytes)
```