### PR TITLE
ESP IDF Compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(COMPONENT_SRCDIRS
+    "src"
+)
+
+set(COMPONENT_ADD_INCLUDEDIRS
+    "src"
+)
+
+set(COMPONENT_REQUIRES
+    "arduino-esp32"
+    "AsyncTCP"
+)
+
+register_component()
+
+target_compile_definitions(${COMPONENT_TARGET} PUBLIC -DESP32)
+target_compile_options(${COMPONENT_TARGET} PRIVATE -fno-rtti)


### PR DESCRIPTION
Somehow in the fork history the `CMakeLists.txt` file was remove which allows this library to be used as an ESP IDF component instead of using the Platform.IO workflow.

To test this you can create a new ESP IDF project (easiest way is to use VSCode ESPIDF plugin) and clone this fork inside the `components/` directory along with your ASyncTCP repo. Use one of the examples and everything should compile.