### PR TITLE
Prevent duplicate sending of headers when overridden by the user

### DIFF
--- a/src/literals.h
+++ b/src/literals.h
@@ -41,7 +41,7 @@ static constexpr const char* T_none             = "none";
 static constexpr const char* T_UPGRADE          = "Upgrade";
 static constexpr const char* T_WS               = "websocket";
 static constexpr const char* T_WWW_AUTH         = "WWW-Authenticate";
-static constexpr const char* Transfer_Encoding  = "Transfer-Encoding";
+static constexpr const char* T_Transfer_Encoding = "Transfer-Encoding";
 
 // HTTP Methods
 static constexpr const char* T_ANY      = "ANY";
@@ -210,7 +210,7 @@ static const char T_none[] PROGMEM = "none";
 static const char T_UPGRADE[] PROGMEM = "Upgrade";
 static const char T_WS[] PROGMEM = "websocket";
 static const char T_WWW_AUTH[] PROGMEM = "WWW-Authenticate";
-static const char Transfer_Encoding[] PROGMEM = "Transfer-Encoding";
+static const char T_Transfer_Encoding[] PROGMEM = "Transfer-Encoding";
 
 // HTTP Methods
 static const char T_ANY[] PROGMEM = "ANY";


### PR DESCRIPTION
This PR fixes #77.

### Description
These new additions can be used to design custom file serving scenario that also supports `HEAD` request to be able to resume downloads and serve 206 partial content.

### Additional notes
The user may control whether these headers are sent using the following methods:
```
response->sendAcceptsRange(false);
response->sendContentLength(false);
```

Which means that if the user sets these to `false`, they are expected to supply their own header values via `addHeader()`.

### Examples
```cpp
server->on("/file/download", HTTP_HEAD|HTTP_GET, [&](AsyncWebServerRequest *request) {
	// ...
	if (request->method() == HTTP_HEAD)
	{
		response = request->beginResponse(200, "application/octet-stream", "");
		response->setContentLength(0);
		response->sendAcceptsRange(false);
		response->sendContentLength(false);
		response->addHeader("Accept-Ranges", "bytes");
		response->addHeader("Content-Length", String((uint32_t) myFile.getSize()));
		// ...
	}
}
```