### PR TITLE
[PERF] AsyncEventSource writes multiple events per tcp send, including partial events that straddle buffers; Improvement: don't hold onto event items until ack, immediately remove them from queue

### DIFF
--- a/src/AsyncEventSource.h
+++ b/src/AsyncEventSource.h
@@ -67,6 +67,7 @@ class AsyncEventSourceMessage {
     AsyncEventSourceMessage(const char* data, size_t len);
     ~AsyncEventSourceMessage();
     size_t ack(size_t len, uint32_t time = 0);
+    size_t write(AsyncClient* client);
     size_t send(AsyncClient* client);
     bool finished() { return _acked == _len; }
     bool sent() { return _sent == _len; }


### PR DESCRIPTION
Copy of PR https://github.com/esphome/ESPAsyncWebServer/pull/41 from @nkinnan

**See the above PR for discussion.**