### PR TITLE
(perf) Remove "interesting headers" to fasten request processing (replaced with `removeHeadersExcept`)

### DIFF
--- a/examples/CaptivePortal/CaptivePortal.ino
+++ b/examples/CaptivePortal/CaptivePortal.ino
@@ -20,7 +20,6 @@ class CaptiveRequestHandler : public AsyncWebHandler {
     virtual ~CaptiveRequestHandler() {}
 
     bool canHandle(__unused AsyncWebServerRequest* request) {
-      // request->addInterestingHeader("ANY");
       return true;
     }
 

--- a/examples/Filters/Filters.ino
+++ b/examples/Filters/Filters.ino
@@ -22,7 +22,6 @@ class CaptiveRequestHandler : public AsyncWebHandler {
     virtual ~CaptiveRequestHandler() {}
 
     bool canHandle(__unused AsyncWebServerRequest* request) {
-      // request->addInterestingHeader("ANY");
       return true;
     }
 

--- a/src/AsyncEventSource.cpp
+++ b/src/AsyncEventSource.cpp
@@ -374,8 +374,6 @@ bool AsyncEventSource::canHandle(AsyncWebServerRequest* request) {
   if (request->method() != HTTP_GET || !request->url().equals(_url)) {
     return false;
   }
-  request->addInterestingHeader(T_Last_Event_ID);
-  request->addInterestingHeader(T_Cookie);
   return true;
 }
 

--- a/src/AsyncJson.h
+++ b/src/AsyncJson.h
@@ -198,7 +198,6 @@ class AsyncCallbackJsonWebHandler : public AsyncWebHandler {
       if (request_method != HTTP_GET && !request->contentType().equalsIgnoreCase(JSON_MIMETYPE))
         return false;
 
-      request->addInterestingHeader("ANY");
       return true;
     }
 

--- a/src/AsyncMessagePack.h
+++ b/src/AsyncMessagePack.h
@@ -97,7 +97,6 @@ class AsyncCallbackMessagePackWebHandler : public AsyncWebHandler {
       if (request_method != HTTP_GET && !request->contentType().equalsIgnoreCase(asyncsrv::T_application_msgpack))
         return false;
 
-      request->addInterestingHeader("ANY");
       return true;
     }
 

--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -1078,13 +1078,6 @@ bool AsyncWebSocket::canHandle(AsyncWebServerRequest* request) {
   if (request->method() != HTTP_GET || !request->url().equals(_url) || !request->isExpectedRequestedConnType(RCT_WS))
     return false;
 
-  request->addInterestingHeader(WS_STR_CONNECTION);
-  request->addInterestingHeader(WS_STR_UPGRADE);
-  request->addInterestingHeader(WS_STR_ORIGIN);
-  request->addInterestingHeader(WS_STR_COOKIE);
-  request->addInterestingHeader(WS_STR_VERSION);
-  request->addInterestingHeader(WS_STR_KEY);
-  request->addInterestingHeader(WS_STR_PROTOCOL);
   return true;
 }
 

--- a/src/WebHandlerImpl.h
+++ b/src/WebHandlerImpl.h
@@ -125,7 +125,6 @@ class AsyncCallbackWebHandler : public AsyncWebHandler {
       } else if (_uri.length() && (_uri != request->url() && !request->url().startsWith(_uri + "/")))
         return false;
 
-      request->addInterestingHeader("ANY");
       return true;
     }
 

--- a/src/WebHandlers.cpp
+++ b/src/WebHandlers.cpp
@@ -23,7 +23,6 @@
 
 using namespace asyncsrv;
 
-
 AsyncStaticWebHandler::AsyncStaticWebHandler(const char* uri, FS& fs, const char* path, const char* cache_control)
     : _fs(fs), _uri(uri), _path(path), _default_file(F("index.htm")), _cache_control(cache_control), _last_modified(), _callback(nullptr) {
   // Ensure leading '/'
@@ -94,18 +93,7 @@ bool AsyncStaticWebHandler::canHandle(AsyncWebServerRequest* request) {
   if (request->method() != HTTP_GET || !request->url().startsWith(_uri) || !request->isExpectedRequestedConnType(RCT_DEFAULT, RCT_HTTP)) {
     return false;
   }
-  if (_getFile(request)) {
-    // We interested in "If-Modified-Since" header to check if file was modified
-    if (_last_modified.length())
-      request->addInterestingHeader(F("If-Modified-Since"));
-
-    if (_cache_control.length())
-      request->addInterestingHeader(F("If-None-Match"));
-
-    return true;
-  }
-
-  return false;
+  return _getFile(request);
 }
 
 bool AsyncStaticWebHandler::_getFile(AsyncWebServerRequest* request) {

--- a/src/WebServer.cpp
+++ b/src/WebServer.cpp
@@ -155,7 +155,6 @@ void AsyncWebServer::_attachHandler(AsyncWebServerRequest* request) {
     }
   }
 
-  request->addInterestingHeader(T_ANY);
   request->setHandler(_catchAllHandler);
 }
 


### PR DESCRIPTION
All headers are already parsed: interesting headers allowed to cleanup parsed headers to only keep interesting ones during request processing.

Headers are anyway all cleaned after request processing.

This removal helps reduce flash size and heap usage (on vector less).