### PR TITLE
add optional responce code to AsyncWebServerRequest::redirect() method

### DIFF
--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -288,12 +288,13 @@ class AsyncWebServerRequest {
     }
 
     /**
-     * @brief issue 302 redirect response
+     * @brief issue HTTP redirect responce with Location header
      *
-     * @param url
+     * @param url - url to redirect to
+     * @param code - responce code, default is 302 : temporary redirect
      */
-    void redirect(const char* url);
-    void redirect(const String& url) { return redirect(url.c_str()); };
+    void redirect(const char* url, int code = 302);
+    void redirect(const String& url, int code = 302) { return redirect(url.c_str(), code); };
 
     void send(AsyncWebServerResponse* response);
     AsyncWebServerResponse* getResponse() const { return _response; }

--- a/src/WebRequest.cpp
+++ b/src/WebRequest.cpp
@@ -766,8 +766,8 @@ void AsyncWebServerRequest::send(AsyncWebServerResponse* response) {
     send(500);
 }
 
-void AsyncWebServerRequest::redirect(const char* url) {
-  AsyncWebServerResponse* response = beginResponse(302);
+void AsyncWebServerRequest::redirect(const char* url, int code) {
+  AsyncWebServerResponse* response = beginResponse(code);
   response->addHeader(T_LOCATION, url);
   send(response);
 }


### PR DESCRIPTION
Allows to specify differents redirect codes to use, i.e. 301/302, 307/308