### PR TITLE
Fix #151: setAuthentication() was not authenticating: the middleware …

### DIFF
--- a/examples/SimpleServer/SimpleServer.ino
+++ b/examples/SimpleServer/SimpleServer.ino
@@ -412,6 +412,9 @@ void setup() {
   // curl -v -X GET http://192.168.4.1/index.txt
   server.serveStatic("/index.txt", LittleFS, "/index.txt");
 
+  // curl -v -X GET http://192.168.4.1/index-private.txt
+  server.serveStatic("/index-private.txt", LittleFS, "/index.txt").setAuthentication("admin", "admin");
+
   // ServeStatic static is used to serve static output which never changes over time.
   // This special endpoints automatyically adds caching headers.
   // If a template processor is used, it must enure that the outputed content will always be the ame over time and never changes.

--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -733,8 +733,8 @@ class AsyncWebHandler : public AsyncMiddlewareChain {
     AsyncWebHandler() {}
     virtual ~AsyncWebHandler() {}
     AsyncWebHandler& setFilter(ArRequestFilterFunction fn);
-    AsyncWebHandler& setAuthentication(const char* username, const char* password);
-    AsyncWebHandler& setAuthentication(const String& username, const String& password) { return setAuthentication(username.c_str(), password.c_str()); };
+    AsyncWebHandler& setAuthentication(const char* username, const char* password, AsyncAuthType authMethod = AsyncAuthType::AUTH_DIGEST);
+    AsyncWebHandler& setAuthentication(const String& username, const String& password, AsyncAuthType authMethod = AsyncAuthType::AUTH_DIGEST) { return setAuthentication(username.c_str(), password.c_str(), authMethod); };
     bool filter(AsyncWebServerRequest* request) { return _filter == NULL || _filter(request); }
     virtual bool canHandle(AsyncWebServerRequest* request __attribute__((unused))) const { return false; }
     virtual void handleRequest(__unused AsyncWebServerRequest* request) {}

--- a/src/WebHandlers.cpp
+++ b/src/WebHandlers.cpp
@@ -27,7 +27,7 @@ AsyncWebHandler& AsyncWebHandler::setFilter(ArRequestFilterFunction fn) {
   _filter = fn;
   return *this;
 }
-AsyncWebHandler& AsyncWebHandler::setAuthentication(const char* username, const char* password) {
+AsyncWebHandler& AsyncWebHandler::setAuthentication(const char* username, const char* password, AsyncAuthType authMethod) {
   if (!_authMiddleware) {
     _authMiddleware = new AuthenticationMiddleware();
     _authMiddleware->_freeOnRemoval = true;
@@ -35,6 +35,7 @@ AsyncWebHandler& AsyncWebHandler::setAuthentication(const char* username, const 
   }
   _authMiddleware->setUsername(username);
   _authMiddleware->setPassword(password);
+  _authMiddleware->setAuthType(authMethod);
   return *this;
 };
 


### PR DESCRIPTION
…was setup with `AUTH_NONE` (default) instead of `AUTH_DIGEST` (to keep backward compatibility)