### PR TITLE
move AsyncWebSocket's WS_EVT_CONNECT callback out of AsyncWebSocketClient's constructor

### DIFF
--- a/examples/SimpleServer/SimpleServer.ino
+++ b/examples/SimpleServer/SimpleServer.ino
@@ -147,6 +147,8 @@ AsyncMiddlewareFunction complexAuth([](AsyncWebServerRequest* request, ArMiddlew
 
 AuthorizationMiddleware authz([](AsyncWebServerRequest* request) { return request->getAttribute("role") == "staff"; });
 
+int wsClients = 0;
+
 /////////////////////////////////////////////////////////////////////////////////////////////////////
 
 const char* PARAM_MESSAGE PROGMEM = "message";
@@ -646,10 +648,14 @@ void setup() {
   ws.onEvent([](AsyncWebSocket* server, AsyncWebSocketClient* client, AwsEventType type, void* arg, uint8_t* data, size_t len) {
     (void)len;
     if (type == WS_EVT_CONNECT) {
+      wsClients++;
+      ws.textAll("new client connected");
       Serial.println("ws connect");
       client->setCloseClientOnQueueFull(false);
       client->ping();
     } else if (type == WS_EVT_DISCONNECT) {
+      wsClients--;
+      ws.textAll("client disconnected");
       Serial.println("ws disconnect");
     } else if (type == WS_EVT_ERROR) {
       Serial.println("ws error");

--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -287,7 +287,6 @@ AsyncWebSocketClient::AsyncWebSocketClient(AsyncWebServerRequest* request, Async
   _client->onTimeout([](void* r, AsyncClient* c, uint32_t time) { (void)c; ((AsyncWebSocketClient*)(r))->_onTimeout(time); }, this);
   _client->onData([](void* r, AsyncClient* c, void* buf, size_t len) { (void)c; ((AsyncWebSocketClient*)(r))->_onData(buf, len); }, this);
   _client->onPoll([](void* r, AsyncClient* c) { (void)c; ((AsyncWebSocketClient*)(r))->_onPoll(); }, this);
-  _server->_handleEvent(this, WS_EVT_CONNECT, request, NULL, 0);
   delete request;
   memset(&_pinfo, 0, sizeof(_pinfo));
 }
@@ -781,6 +780,7 @@ void AsyncWebSocket::_handleEvent(AsyncWebSocketClient* client, AwsEventType typ
 
 AsyncWebSocketClient* AsyncWebSocket::_newClient(AsyncWebServerRequest* request) {
   _clients.emplace_back(request, this);
+  _handleEvent(&_clients.back(), WS_EVT_CONNECT, request, NULL, 0);
   return &_clients.back();
 }
 


### PR DESCRIPTION
Replaces https://github.com/mathieucarbou/ESPAsyncWebServer/pull/177