### PR TITLE
Reset connection when appropriate + some code cleanup

### DIFF
--- a/examples/SimpleServer/SimpleServer.ino
+++ b/examples/SimpleServer/SimpleServer.ino
@@ -750,6 +750,10 @@ websocat: error running
     }
   });
 
+  // Reset connection on HTTP request:
+  // for i in {1..20}; do curl -v -X GET https://192.168.4.1:80; done;
+  // The heap size should not decrease over time.
+
 #if __has_include("ArduinoJson.h")
   server.addHandler(jsonHandler);
   server.addHandler(msgPackHandler);

--- a/src/WebServer.cpp
+++ b/src/WebServer.cpp
@@ -56,8 +56,7 @@ AsyncWebServer::AsyncWebServer(uint16_t port)
     c->setRxTimeout(3);
     AsyncWebServerRequest* r = new AsyncWebServerRequest((AsyncWebServer*)s, c);
     if (r == NULL) {
-      c->close(true);
-      c->free();
+      c->abort();
       delete c;
     }
   },


### PR DESCRIPTION
I went over the code base to do a little cleanup of the calls to close() which should instead be abort when related to connection problems or request parsing problems.


ChatGPT summarises the use cases pretty well: https://chatgpt.com/share/6763e68c-8900-8007-b540-16156d04d13c
