### PR TITLE
Remove libCompatMode from library.json

### DIFF
--- a/library.json
+++ b/library.json
@@ -61,8 +61,5 @@
       "LICENSE",
       "README.md"
     ]
-  },
-  "build": {
-    "libCompatMode": "strict"
   }
 }


### PR DESCRIPTION
Specifying libCompatMode in library.json prevents projects from overriding the library compatibility mode as needed. This prevents the library from being used in builds where Arduino is a component to ESP-IDF.

If merged, this will resolve #188 