### PR TITLE
rework INM/IMS handling for AsyncStaticWebHandler

### DIFF
--- a/src/WebHandlerImpl.h
+++ b/src/WebHandlerImpl.h
@@ -57,12 +57,19 @@ class AsyncStaticWebHandler : public AsyncWebHandler {
     AsyncStaticWebHandler& setIsDir(bool isDir);
     AsyncStaticWebHandler& setDefaultFile(const char* filename);
     AsyncStaticWebHandler& setCacheControl(const char* cache_control);
+
+    /**
+     * @brief Set the Last-Modified time for the object
+     * 
+     * @param last_modified 
+     * @return AsyncStaticWebHandler& 
+     */
     AsyncStaticWebHandler& setLastModified(const char* last_modified);
     AsyncStaticWebHandler& setLastModified(struct tm* last_modified);
-#ifdef ESP8266
     AsyncStaticWebHandler& setLastModified(time_t last_modified);
-    AsyncStaticWebHandler& setLastModified(); // sets to current time. Make sure sntp is runing and time is updated
-#endif
+    // sets to current time. Make sure sntp is runing and time is updated
+    AsyncStaticWebHandler& setLastModified();
+
     AsyncStaticWebHandler& setTemplateProcessor(AwsTemplateProcessor newCallback);
 };
 


### PR DESCRIPTION
Have faced some problems where I received wrong 304 replies for static files.
The issue was that if some file generated and written on filesystem before WiFi connects and aqures proper time file's timestamp was about +2 +3 seconds UTC and that could lead to improper 304 replies to the clients that was previously had this file.
So I've added some fixes and improvements

 - IMS template [must](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Last-Modified) contain GMT timezone, not local - "%a, %d %b %Y %H:%M:%S GMT"
server used to reply with local timezone specifier but used GMT time.

 - create etag header based on timestamp + filesize, it adds a bit of entropy for files which are created soon after boot

 - INM header handling should have precedence over IMS when checking if content is not modified and since etag already includes timestamp further check could be skipped


